### PR TITLE
chore: bitcoinjs migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
-        "@exodus/bitcoinjs-lib": "^6.1.6",
+        "@exodus/bitcoinjs": "^1.3.0",
         "@exodus/secp256k1": "^4.0.2-exodus.0",
         "@types/bn.js": "^4.11.3",
         "bech32": "^1.1.2",
@@ -322,36 +322,25 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "node_modules/@exodus/bitcoinerlab-secp256k1": {
-      "version": "1.0.5-exodus.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bitcoinerlab-secp256k1/-/bitcoinerlab-secp256k1-1.0.5-exodus.1.tgz",
-      "integrity": "sha512-vk4WBauCD9YmH4nO7loye6gpoFUAFlx9D+s3/1M5ayp9AD9yBRNTujb2lgWeZuJbyeJpiAJBEKwLS1QrVJdwrg==",
+    "node_modules/@exodus/bitcoinjs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bitcoinjs/-/bitcoinjs-1.3.0.tgz",
+      "integrity": "sha512-CrZTzprJ55fF4Mb+bvqq6byVr/m/4BmKSm3qezvyQ0lU2CR85tnSRLx6G/SSytv8yvFr+xgRwjXeEPW94SnHcA==",
       "dependencies": {
-        "@noble/hashes": "^1.1.5",
+        "@exodus/crypto": "^1.0.0-rc.12",
+        "bip174": "^2.1.1",
+        "bitcoinjs-lib": "^6.1.6",
+        "ecpair": "^2.0.1"
+      }
+    },
+    "node_modules/@exodus/crypto": {
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@exodus/crypto/-/crypto-1.0.0-rc.14.tgz",
+      "integrity": "sha512-defGyuIB73TOZBQaY+sR14hrixhNTtGqZawmLidHTz1YwmkfDLpr0BbB14eLw6FdCFfXReLCivH7YKjArq8V1Q==",
+      "dependencies": {
+        "@noble/hashes": "^1.3.3",
         "@noble/secp256k1": "^1.7.1"
       }
-    },
-    "node_modules/@exodus/bitcoinjs-lib": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@exodus/bitcoinjs-lib/-/bitcoinjs-lib-6.1.6.tgz",
-      "integrity": "sha512-FJenJiOC+lNPW/qkyjLr8k2SVXvSoc8xB9V3LphIay6JCg2dQA4ZTw4sAnBkIeC3t10vkQSjaWGUNZ9qe7hzNw==",
-      "dependencies": {
-        "@exodus/bitcoinerlab-secp256k1": "^1.0.5-exodus.1",
-        "@noble/hashes": "^1.2.0",
-        "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@exodus/bitcoinjs-lib/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@exodus/secp256k1": {
       "version": "4.0.2-exodus.0",
@@ -649,6 +638,27 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/bitcoinjs-lib": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.6.tgz",
+      "integrity": "sha512-Fk8+Vc+e2rMoDU5gXkW9tD+313rhkm5h6N9HfZxXvYU9LedttVvmXKTgd9k5rsQJjkSfsv6XRM8uhJv94SrvcA==",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bech32": "^2.0.0",
+        "bip174": "^2.1.1",
+        "bs58check": "^3.0.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/bn.js": {
       "version": "4.11.8",
@@ -1014,6 +1024,19 @@
       },
       "bin": {
         "ignored": "bin/ignored"
+      }
+    },
+    "node_modules/ecpair": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-2.1.0.tgz",
+      "integrity": "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==",
+      "dependencies": {
+        "randombytes": "^2.1.0",
+        "typeforce": "^1.18.0",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/elliptic": {
@@ -3308,6 +3331,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/re-emitter": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
@@ -4250,6 +4281,40 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "node_modules/wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "dependencies": {
+        "bs58check": "<3.0.0"
+      }
+    },
+    "node_modules/wif/node_modules/base-x": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/wif/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/wif/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -4631,34 +4696,24 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@exodus/bitcoinerlab-secp256k1": {
-      "version": "1.0.5-exodus.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bitcoinerlab-secp256k1/-/bitcoinerlab-secp256k1-1.0.5-exodus.1.tgz",
-      "integrity": "sha512-vk4WBauCD9YmH4nO7loye6gpoFUAFlx9D+s3/1M5ayp9AD9yBRNTujb2lgWeZuJbyeJpiAJBEKwLS1QrVJdwrg==",
+    "@exodus/bitcoinjs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bitcoinjs/-/bitcoinjs-1.3.0.tgz",
+      "integrity": "sha512-CrZTzprJ55fF4Mb+bvqq6byVr/m/4BmKSm3qezvyQ0lU2CR85tnSRLx6G/SSytv8yvFr+xgRwjXeEPW94SnHcA==",
       "requires": {
-        "@noble/hashes": "^1.1.5",
-        "@noble/secp256k1": "^1.7.1"
+        "@exodus/crypto": "^1.0.0-rc.12",
+        "bip174": "^2.1.1",
+        "bitcoinjs-lib": "^6.1.6",
+        "ecpair": "^2.0.1"
       }
     },
-    "@exodus/bitcoinjs-lib": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@exodus/bitcoinjs-lib/-/bitcoinjs-lib-6.1.6.tgz",
-      "integrity": "sha512-FJenJiOC+lNPW/qkyjLr8k2SVXvSoc8xB9V3LphIay6JCg2dQA4ZTw4sAnBkIeC3t10vkQSjaWGUNZ9qe7hzNw==",
+    "@exodus/crypto": {
+      "version": "1.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/@exodus/crypto/-/crypto-1.0.0-rc.14.tgz",
+      "integrity": "sha512-defGyuIB73TOZBQaY+sR14hrixhNTtGqZawmLidHTz1YwmkfDLpr0BbB14eLw6FdCFfXReLCivH7YKjArq8V1Q==",
       "requires": {
-        "@exodus/bitcoinerlab-secp256k1": "^1.0.5-exodus.1",
-        "@noble/hashes": "^1.2.0",
-        "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-        }
+        "@noble/hashes": "^1.3.3",
+        "@noble/secp256k1": "^1.7.1"
       }
     },
     "@exodus/secp256k1": {
@@ -4880,6 +4935,26 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
       "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ=="
+    },
+    "bitcoinjs-lib": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.6.tgz",
+      "integrity": "sha512-Fk8+Vc+e2rMoDU5gXkW9tD+313rhkm5h6N9HfZxXvYU9LedttVvmXKTgd9k5rsQJjkSfsv6XRM8uhJv94SrvcA==",
+      "requires": {
+        "@noble/hashes": "^1.2.0",
+        "bech32": "^2.0.0",
+        "bip174": "^2.1.1",
+        "bs58check": "^3.0.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        }
+      }
     },
     "bn.js": {
       "version": "4.11.8",
@@ -5194,6 +5269,16 @@
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "ecpair": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-2.1.0.tgz",
+      "integrity": "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==",
+      "requires": {
+        "randombytes": "^2.1.0",
+        "typeforce": "^1.18.0",
+        "wif": "^2.0.6"
       }
     },
     "elliptic": {
@@ -6984,6 +7069,14 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "re-emitter": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
@@ -7749,6 +7842,42 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "requires": {
+        "bs58check": "<3.0.0"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.10",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+          "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
+        "bs58check": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+          "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+          "requires": {
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
+          }
+        }
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
   },
   "homepage": "https://github.com/bitcoinjs/bolt11#readme",
   "dependencies": {
+    "@exodus/bitcoinjs": "^1.3.0",
+    "@exodus/secp256k1": "^4.0.2-exodus.0",
     "@types/bn.js": "^4.11.3",
     "bech32": "^1.1.2",
-    "@exodus/bitcoinjs-lib": "^6.1.6",
     "bn.js": "^4.11.8",
     "create-hash": "^1.2.0",
     "lodash": "^4.17.11",
-    "safe-buffer": "^5.1.1",
-    "@exodus/secp256k1": "^4.0.2-exodus.0"
+    "safe-buffer": "^5.1.1"
   }
 }

--- a/payreq.js
+++ b/payreq.js
@@ -5,8 +5,14 @@ const bech32 = require('bech32')
 const secp256k1 = require('@exodus/secp256k1')
 const Buffer = require('safe-buffer').Buffer
 const BN = require('bn.js')
-const bitcoinjsAddress = require('@exodus/bitcoinjs-lib').address
 const cloneDeep = require('lodash/cloneDeep')
+
+let bitcoinjsAddress
+
+(async () => {
+  const bitcoinjs = await import('@exodus/bitcoinjs')
+  bitcoinjsAddress = bitcoinjs.address
+})()
 
 // defaults for encode; default timestamp is current time at call
 const DEFAULTNETWORK = {


### PR DESCRIPTION
it unforks `@exodus/bitcoinjs-lib` towards `@exodus/bitcoinjs`. One alternative is to migrate the module to esm, but that's a larger refactoring.

## Test Plan
- [x] `yarn test` is ok